### PR TITLE
Deprecation banner on the spades-experiment website (points to SpaDES.project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 <img align="right" width="80" vspace="10" hspace="10" src="https://github.com/PredictiveEcology/SpaDES/raw/master/docs/images/SpaDES.png">
 
+> ⚠️ **`SpaDES.experiment` is deprecated and no longer maintained.**
+> Its experiment functionality has moved to
+> [`SpaDES.project`](https://spades-project.predictiveecology.org), which is now
+> its maintained home: `experiment()`, `experiment2()`, `simInitAndExperiment()`,
+> the `simLists` class and `as.data.table.simLists()` all live there. The
+> same-named functions here simply forward to `SpaDES.project`. Please migrate:
+> `remotes::install_github("PredictiveEcology/SpaDES.project")`.
+
 # SpaDES.experiment
 
 Tools to build simulation experiments within the `SpaDES` ecosystem.

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,17 @@
       </header><div class="row">
   <div class="contents col-md-9">
 
+<div class="alert alert-warning" style="border-left:5px solid #d9534f; font-size:1.05em;">
+  <strong>⚠️ <code>SpaDES.experiment</code> is deprecated and no longer maintained.</strong>
+  Its experiment functionality has moved to
+  <a href="https://spades-project.predictiveecology.org"><code>SpaDES.project</code></a>,
+  which is now its maintained home: <code>experiment()</code>, <code>experiment2()</code>,
+  <code>simInitAndExperiment()</code>, the <code>simLists</code> class and
+  <code>as.data.table.simLists()</code> all live there. The same-named functions here
+  simply forward to <code>SpaDES.project</code>. Please migrate:
+  <code>remotes::install_github("PredictiveEcology/SpaDES.project")</code>.
+</div>
+
 
 <p><img align="right" width="80" vspace="10" hspace="10" src="https://github.com/PredictiveEcology/SpaDES/raw/master/docs/images/SpaDES.png"></p>
 <div id="spades-experiment" class="section level1">


### PR DESCRIPTION
Adds a prominent **deprecation banner** to the package home page so visitors to <https://spades-experiment.predictiveecology.org> are told the package is no longer maintained and pointed to **SpaDES.project**.

The live site is served from `master/docs/` (legacy GitHub Pages, `source: master /docs`). Since this is a frozen/deprecated package, rather than do a full pkgdown rebuild of the old (v0.0.1) tree, this PR:
- adds the banner to `README.md` (source of truth), and
- injects the same banner into the rendered `docs/index.html` so the live home updates as soon as this merges into `master`.

Companion to the deprecation work in PR #21 (which turns the functions into forwarding shims on `development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)